### PR TITLE
Added a fix when ebpf is enabled on the loopback to forward all traff…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+# [0.5.9] - 2024-02-09
+
+###
+
+- Fixed an issue where if an ingress tc filter is applied to the loopback interface traffic is dropped if it does not specifically 
+  match a rule.  The correct action is to pass all traffic to the loopback unless there is a rule explicitly redirecting.
+  the traffic to either a tproxy port or ziti(tun) interface.
+
 # [0.5.8] - 2024-01-28
 
 ###

--- a/src/zfw.c
+++ b/src/zfw.c
@@ -152,7 +152,7 @@ char *tc_interface;
 char *log_file_name;
 char *object_file;
 char *direction_string;
-const char *argp_program_version = "0.5.8";
+const char *argp_program_version = "0.5.9";
 struct ring_buffer *ring_buffer;
 
 __u8 if_list[MAX_IF_LIST_ENTRIES];

--- a/src/zfw_tc_ingress.c
+++ b/src/zfw_tc_ingress.c
@@ -1289,6 +1289,8 @@ int bpf_sk_splice4(struct __sk_buff *skb){
             if(dmask == 0x00000000){
                 if((tracked_key_data->count > 0)){
                     return TC_ACT_PIPE;
+                }else if(skb->ingress_ifindex == 1){
+                    return TC_ACT_OK;
                 }
             }
             iterate_masks(&dmask, &dexponent);


### PR DESCRIPTION
…ic that is in ingress on the loopback interface unless a specific rule redirects traffic to either a tproxy port or a ziti(tun) interface