### PR TITLE
Fixed issue where if ziti-edge-tunnel is stopped and wildcard entries…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+# [0.7.1] - 2024-05-28
+
+###
+
+- Fixed issue where if ziti-edge-tunnel is stopped and wildcard entries exist they will re-populate on start unless rebooted or ebpf disabled and re-enabled.  
+
 # [0.7.0] - 2024-05-26
 
 ###

--- a/src/zfw.c
+++ b/src/zfw.c
@@ -182,7 +182,7 @@ char *log_file_name;
 char *object_file;
 char *direction_string;
 
-const char *argp_program_version = "0.7.0";
+const char *argp_program_version = "0.7.1";
 struct ring_buffer *ring_buffer;
 
 __u32 if_list[MAX_IF_LIST_ENTRIES];


### PR DESCRIPTION
… exist they will re-populate on start unless rebooted or ebpf disabled and re-enabled.