### PR TITLE
redirect system call output to /dev/null for set_tc_filter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. The format 
 ---
 ###
 
+# [0.9.56 - 2024-12-09
+
+- Updated zfw.c to redirect system call output to /dev/null for set_tc_filter() 
+  
+###
+
 # [0.9.5] - 2024-11-29
 
 - updated the release workflow to upload zfw-router deb package to jfrog repo

--- a/src/zfw_monitor.c
+++ b/src/zfw_monitor.c
@@ -87,7 +87,7 @@ char check_alt[IF_NAMESIZE];
 char doc[] = "zfw_monitor -- ebpf firewall monitor tool";
 const char *rb_map_path = "/sys/fs/bpf/tc/globals/rb_map";
 const char *tproxy_map_path = "/sys/fs/bpf/tc/globals/zt_tproxy_map";
-const char *argp_program_version = "0.9.5";
+const char *argp_program_version = "0.9.6";
 union bpf_attr rb_map;
 int rb_fd = -1;
 


### PR DESCRIPTION
Updated zfw.c to redirect system call output to /dev/null for set_tc_filter()