### PR TITLE
V0.9.21 release candidate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ env:
   NF_NETWORK_NAME: 'dariuszdev02'
   TF_VAR_test_iterate_count: ${{ fromJSON(vars.TEST_ITERATE_COUNT) }}
   TF_VAR_github_pt: ${{ secrets.PAT  }}
+  TF_VAR_ziti_type: ${{ vars.ZITI_TYPE }}
+  TF_VAR_repo_name: ${{ vars.REPO_NAME }}
   NF_API_CLIENT_ID: "${{ secrets.NF_API_CLIENT_ID }}"
   NF_API_CLIENT_SECRET: "${{ secrets.NF_API_CLIENT_SECRET }}"
 
@@ -301,18 +303,26 @@ jobs:
           cd ${{ github.workspace }}/AWS/tf-provider/
           zfw0_ver=`/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo /opt/openziti/bin/zfw -V'`
           zfw1_ver=`/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo /opt/openziti/bin/zfw -V'`
-          if [ "$zfw0_ver" != "$zfw1_ver" ]; then
-            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo cat /var/log/cloud-init-output.log'
-            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo cat /var/log/cloud-init-output.log'
-            sleep 60
-            zfw0_ver=`/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo /opt/openziti/bin/zfw -V'`
-            zfw1_ver=`/usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo /opt/openziti/bin/zfw -V'`
-          fi
           echo "*** zfw0: $zfw0_ver ***"
           echo "*** zfw1: $zfw1_ver ***"
+          if [ "${{ vars.DEBUG }}" == "true" ] || [ "$zfw0_ver" != "$zfw1_ver" ]; then
+            sleep 60
+            echo -e "\033[31mDebug mode ${{ vars.DEBUG }}, printing debug info for zfw0\033[m"
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo cat /var/log/cloud-init-output.log'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo ls -l /opt/netfoundry/'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo cat /opt/netfoundry/dl_artifacts_zfw.sh'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo ls -l /var/lib/cloud/instance/scripts/'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[0]) -tq 'sudo cat /var/lib/cloud/instance/scripts/runcmd'
+            echo -e "\033[31mDebug mode ${{ vars.DEBUG }}, printing debug info for zfw1\033[m"
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo cat /var/log/cloud-init-output.log'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo ls -l /opt/netfoundry/'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo cat /opt/netfoundry/dl_artifacts_zfw.sh'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo ls -l /var/lib/cloud/instance/scripts/'
+            /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .backend_public_ips.value[1]) -tq 'sudo cat /var/lib/cloud/instance/scripts/runcmd'
+          fi
           while :
           do
-            sleep 900
+            sleep ${{ fromJSON(vars.LOOP_SLEEP_TIMER) }}
             /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .client_public_ips.value[0]) -tq '/usr/bin/tail -n 1 /var/log/http_test.json' > ${{ github.workspace }}/AWS/tf-provider/result
             /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .client_public_ips.value[1]) -tq '/usr/bin/tail -n 1 /var/log/http_test.json' >> ${{ github.workspace }}/AWS/tf-provider/result
             /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .client_public_ips.value[0]) -tq '/usr/bin/tail -n 30 /var/log/http.log' > ${{ github.workspace }}/AWS/tf-provider/test.log
@@ -337,7 +347,29 @@ jobs:
               cat ./test.log
               exit 1
             else
+              echo -e "\033[33mResult File\033[m"
               cat ./result
+              if [ "${{ vars.DEBUG }}" == "true" ]; then
+                echo -e "\033[33mLog File\033[m"
+                cat ./test.log
+                /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .client_public_ips.value[0]) -tq '/usr/bin/pgrep -f http' > ${{ github.workspace }}/AWS/tf-provider/pgrep.log
+                /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./zfw_rsa ziggy@$(terraform output -json | jq -r .client_public_ips.value[1]) -tq '/usr/bin/pgrep -f http' >> ${{ github.workspace }}/AWS/tf-provider/pgrep.log
+                count=`cat ./pgrep.log | wc -l`
+                echo "Count: $count"
+                if [ $count -eq 0 ]; then
+                  echo -e "\033[31mFAILED, http app is not running\033[m"
+                  cat ./pgrep.log
+                elif [ $count -eq 1 ]; then
+                  echo -e "\033[33mPARTIALLYPASSED, http app is running on one client\033[m"
+                  cat ./pgrep.log
+                elif [ $count -eq 2 ]; then
+                  echo -e "\033[32mPASSED, http app is running on both clients\033[m"
+                  cat ./pgrep.log
+                else
+                  echo -e "\033[31mFAILED, unexpected number of http apps running: $count\033[m"
+                  cat ./pgrep.log
+                fi
+              fi
               continue
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file. The format 
 ---
 ###
 
+# [0.9.21] - 2025-7-18
+
+- Refactored port_extension_key.pad to  port_extension_key.type to differentiate ipv4 from ipv6
+  range/interface maps so that they are not ambiguous in the case of all zeros prefix/len with 
+  matching ifindex/lowport values.
+- Fixed issue in zfw_tunnel_wrapper.c that could cause a rule cleanup issue on exit.
+- Refactored pr.yml due to changes in the regression test pattern.
+
+###
+
 # [0.9.20] - 2025-7-18
 
 - Refactored cli sanitization to only block '-' at start of argument and removed 

--- a/src/zfw.c
+++ b/src/zfw.c
@@ -278,7 +278,7 @@ char *direction_string;
 char *masq_interface;
 char check_alt[IF_NAMESIZE];
 
-const char *argp_program_version = "0.9.20";
+const char *argp_program_version = "0.9.21";
 struct ring_buffer *ring_buffer;
 
 __u32 if_list[MAX_IF_LIST_ENTRIES];
@@ -381,23 +381,20 @@ struct interface6
     uint32_t addresses[MAX_ADDRESSES][4];
 };
 
-struct port_extension_key
-{
-    union
-    {
+struct port_extension_key {
+    union {
         __u32 ip;
         __u32 ip6[4];
-    } __in46_u_dst;
-    union
-    {
+    }__in46_u_dst;
+    union {
         __u32 ip;
         __u32 ip6[4];
-    } __in46_u_src;
+    }__in46_u_src;
     __u16 low_port;
     __u8 dprefix_len;
     __u8 sprefix_len;
     __u8 protocol;
-    __u8 pad;
+    __u8 type;
 };
 
 struct if_list_extension_mapping
@@ -1096,7 +1093,7 @@ void print_rule6(struct tproxy6_key *key, struct tproxy_tuple *tuple, int *rule_
     port_ext_key.dprefix_len = key->dprefix_len;
     port_ext_key.sprefix_len = key->sprefix_len;
     port_ext_key.protocol = key->protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 6;
     char saddr6[INET6_ADDRSTRLEN];
     char daddr6[INET6_ADDRSTRLEN];
     struct in6_addr saddr_6 = {0};
@@ -1374,7 +1371,7 @@ void print_rule(struct tproxy_key *key, struct tproxy_tuple *tuple, int *rule_co
     port_ext_key.dprefix_len = key->dprefix_len;
     port_ext_key.sprefix_len = key->sprefix_len;
     port_ext_key.protocol = key->protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 4;
     port_range_map->key = (uint64_t)&port_ext_key;
 
     struct range_mapping range_value;
@@ -4245,7 +4242,7 @@ void map_insert6()
     port_ext_key.dprefix_len = dplen;
     port_ext_key.sprefix_len = splen;
     port_ext_key.protocol = protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 6;
     if (protocol == IPPROTO_UDP)
     {
         printf("Adding UDP mapping\n");
@@ -4411,7 +4408,7 @@ void map_insert()
     port_ext_key.dprefix_len = dplen;
     port_ext_key.sprefix_len = splen;
     port_ext_key.protocol = protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 4;
     if (protocol == IPPROTO_UDP)
     {
         printf("Adding UDP mapping\n");
@@ -4595,7 +4592,7 @@ void range_delete_key(struct port_extension_key key)
     {
         char *saddr;
         char *daddr;
-        if (cd)
+        if (key.type == 4)
         {
             saddr = nitoa(ntohl(key.__in46_u_src.ip));
             daddr = nitoa(ntohl(key.__in46_u_dst.ip));
@@ -4782,7 +4779,7 @@ void map_delete6()
     port_ext_key.dprefix_len = dplen;
     port_ext_key.sprefix_len = splen;
     port_ext_key.protocol = protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 6;
     int fd = syscall(__NR_bpf, BPF_OBJ_GET, &map, sizeof(map));
     if (fd == -1)
     {
@@ -4955,7 +4952,7 @@ void map_delete()
     port_ext_key.dprefix_len = dplen;
     port_ext_key.sprefix_len = splen;
     port_ext_key.protocol = protocol;
-    port_ext_key.pad = 0;
+    port_ext_key.type = 4;
     int fd = syscall(__NR_bpf, BPF_OBJ_GET, &map, sizeof(map));
     if (fd == -1)
     {

--- a/src/zfw_monitor.c
+++ b/src/zfw_monitor.c
@@ -93,7 +93,7 @@ char check_alt[IF_NAMESIZE];
 char doc[] = "zfw_monitor -- ebpf firewall monitor tool";
 const char *rb_map_path = "/sys/fs/bpf/tc/globals/rb_map";
 const char *tproxy_map_path = "/sys/fs/bpf/tc/globals/zt_tproxy_map";
-const char *argp_program_version = "0.9.20";
+const char *argp_program_version = "0.9.21";
 union bpf_attr rb_map;
 int rb_fd = -1;
 

--- a/src/zfw_tc_ingress.c
+++ b/src/zfw_tc_ingress.c
@@ -116,7 +116,7 @@ struct port_extension_key {
     __u8 dprefix_len;
     __u8 sprefix_len;
     __u8 protocol;
-    __u8 pad;
+    __u8 type;
 };
 
 struct wildcard_port_key {
@@ -3603,7 +3603,7 @@ int bpf_sk_splice5(struct __sk_buff *skb){
                     ext_key.dprefix_len = key.dprefix_len;
                     ext_key.sprefix_len = key.sprefix_len; 
                     ext_key.protocol = key.protocol;
-                    ext_key.pad = 0;
+                    ext_key.type = 4;
                     struct range_mapping *range = get_range_ports(ext_key);
                     //check if there is a udp or tcp destination port match
                     if (range && ((bpf_ntohs(tuple->ipv4.dport) >= bpf_ntohs(port_key))
@@ -3804,7 +3804,7 @@ int bpf_sk_splice5(struct __sk_buff *skb){
                 ext_key.dprefix_len = key->dprefix_len;
                 ext_key.sprefix_len = key->sprefix_len; 
                 ext_key.protocol = key->protocol;
-                ext_key.pad = 0;
+                ext_key.type = 6;
                 for (int index = 0; index < max_entries; index++){
                     __u16 port_key = tproxy->index_table[index];
                     ext_key.low_port = port_key;

--- a/src/zfw_tc_outbound_track.c
+++ b/src/zfw_tc_outbound_track.c
@@ -293,7 +293,7 @@ struct port_extension_key {
     __u8 dprefix_len;
     __u8 sprefix_len;
     __u8 protocol;
-    __u8 pad;
+    __u8 type;
 };
 
 struct tproxy_extension_mapping {
@@ -2221,7 +2221,7 @@ int bpf_sk_splice5(struct __sk_buff *skb){
                     ext_key.dprefix_len = key.dprefix_len;
                     ext_key.sprefix_len = key.sprefix_len; 
                     ext_key.protocol = key.protocol;
-                    ext_key.pad = 0;
+                    ext_key.type = 4;
                     struct range_mapping *range = get_range_ports(ext_key);
                     //check if there is a udp or tcp destination port match
                     if (range && ((bpf_ntohs(tuple->ipv4.dport) >= bpf_ntohs(port_key))
@@ -2320,7 +2320,7 @@ int bpf_sk_splice5(struct __sk_buff *skb){
                 ext_key.dprefix_len = key->dprefix_len;
                 ext_key.sprefix_len = key->sprefix_len; 
                 ext_key.protocol = key->protocol;
-                ext_key.pad = 0;
+                ext_key.type = 6;
                 for (int index = 0; index < max_entries; index++){
                     __u16 port_key = tproxy->index_table[index];
                     ext_key.low_port = port_key;

--- a/src/zfw_tunnel_wrapper.c
+++ b/src/zfw_tunnel_wrapper.c
@@ -82,7 +82,7 @@ struct port_extension_key {
     __u8 dprefix_len;
     __u8 sprefix_len;
     __u8 protocol;
-    __u8 pad;
+    __u8 type;
 };
 
 const char *transp_map_path = "/sys/fs/bpf/tc/globals/zet_transp_map";
@@ -328,7 +328,7 @@ void process_service_updates(char * service_id)
                 port_ext_key.dprefix_len = current_key.dprefix_len;
                 port_ext_key.sprefix_len = current_key.sprefix_len;
                 port_ext_key.protocol = current_key.protocol,
-                port_ext_key.pad = 0;
+                port_ext_key.type = 4;
                 range_map.key = (uint64_t)&port_ext_key;
                 struct range_mapping range_ports = {0};
                 range_map.value = (uint64_t)&range_ports;
@@ -399,7 +399,7 @@ bool rule_exists(uint32_t dst_ip, uint8_t dplen, uint32_t src_ip, uint8_t splen,
                 port_ext_key.dprefix_len = current_key.dprefix_len;
                 port_ext_key.sprefix_len = current_key.sprefix_len;
                 port_ext_key.protocol = current_key.protocol,
-                port_ext_key.pad = 0;
+                port_ext_key.type = 4;
                 range_map.key = (uint64_t)&port_ext_key;
                 struct range_mapping range_ports = {0};
                 range_map.value = (uint64_t)&range_ports;
@@ -468,8 +468,8 @@ void process_rules()
                 port_ext_key.low_port = orule.index_table[x];
                 port_ext_key.dprefix_len = current_key.dprefix_len;
                 port_ext_key.sprefix_len = current_key.sprefix_len;
-                port_ext_key.protocol = current_key.protocol,
-                port_ext_key.pad = 0;
+                port_ext_key.protocol = current_key.protocol;
+                port_ext_key.type = 4;
                 range_map.key = (uint64_t)&port_ext_key;
                 struct range_mapping range_ports = {0};
                 range_map.value = (uint64_t)&range_ports;

--- a/src/zfw_tunnel_wrapper.c
+++ b/src/zfw_tunnel_wrapper.c
@@ -327,7 +327,7 @@ void process_service_updates(char * service_id)
                 port_ext_key.low_port = orule.index_table[x];
                 port_ext_key.dprefix_len = current_key.dprefix_len;
                 port_ext_key.sprefix_len = current_key.sprefix_len;
-                port_ext_key.protocol = current_key.protocol,
+                port_ext_key.protocol = current_key.protocol;
                 port_ext_key.type = 4;
                 range_map.key = (uint64_t)&port_ext_key;
                 struct range_mapping range_ports = {0};
@@ -398,7 +398,7 @@ bool rule_exists(uint32_t dst_ip, uint8_t dplen, uint32_t src_ip, uint8_t splen,
                 port_ext_key.low_port = orule.index_table[x];
                 port_ext_key.dprefix_len = current_key.dprefix_len;
                 port_ext_key.sprefix_len = current_key.sprefix_len;
-                port_ext_key.protocol = current_key.protocol,
+                port_ext_key.protocol = current_key.protocol;
                 port_ext_key.type = 4;
                 range_map.key = (uint64_t)&port_ext_key;
                 struct range_mapping range_ports = {0};


### PR DESCRIPTION
- Refactored port_extension_key.pad to  port_extension_key.type to differentiate ipv4 from ipv6
  range/interface maps so that they are not ambiguous in the case of all zeros prefix/len with 
  matching ifindex/lowport values.
- Fixed issues in zfw_tunnel_wrapper.c that could cause a rule cleanup issue on exit.
- Refactored pr.yml due to changes in the regression test pattern.